### PR TITLE
feat: add most recommended to feed page

### DIFF
--- a/ui/src/pages/App.svelte
+++ b/ui/src/pages/App.svelte
@@ -103,7 +103,7 @@
             {version}
           </div>
         </div>
-        <div>
+        <div class="overflow-hidden">
           <div class="text-2xl font-bold">
             Current {title} hash
           </div>

--- a/ui/src/pages/App.svelte
+++ b/ui/src/pages/App.svelte
@@ -34,6 +34,7 @@
   $: {
     let { wild } = params;
     itemKey = `/app/${wild}`;
+    cord = wild.split('/')[1];
     loadApp($state);
   }
   const loadApp = (s) => {
@@ -53,6 +54,7 @@
     } = getMeta(item));
     isInstalling =
       s.apps?.[cord]?.chad?.hasOwnProperty('install') || isInstalling;
+
     isInstalled = !isInstalling && !!s.apps?.[cord];
   };
 

--- a/ui/src/pages/Feed.svelte
+++ b/ui/src/pages/Feed.svelte
@@ -7,6 +7,7 @@
     getGlobalFeed,
     getCuratorFeed,
     keyStrToObj,
+    getCollectedItemLeaderboard,
   } from '@root/state';
   import {
     Feed,
@@ -24,6 +25,7 @@
   import { fromUrbitTime, isValidPatp } from '@root/util';
 
   let sortedPals = [];
+  let sortedRecommendations = [];
   let patpItemCount = {};
   let feed;
   state.subscribe((s) => {
@@ -61,6 +63,8 @@
         return (patpItemCount[`~${b}`] || 0) - (patpItemCount[`~${a}`] || 0);
       });
     }
+
+    sortedRecommendations = getCollectedItemLeaderboard(me).slice(0, 4);
   });
 
   let searchShip;
@@ -116,6 +120,14 @@
         </div>
       </div>
     </SidebarGroup>
+    {#if sortedRecommendations.length > 0}
+      <SidebarGroup>
+        <div class="text-xl font-bold mx-2">Most recommended</div>
+        {#each sortedRecommendations as [recommendation, count]}
+          <ItemVerticalListPreview key={keyStrToObj(recommendation)} small />
+        {/each}
+      </SidebarGroup>
+    {/if}
     {#if $state.radioStations}
       <SidebarGroup>
         <div class="text-xl font-bold mx-2">Jump into %radio 📻</div>

--- a/ui/src/state.js
+++ b/ui/src/state.js
@@ -171,6 +171,28 @@ export const getItem = (listKey) => {
   return get(state)[listKey];
 };
 
+export const getCollectedItemLeaderboard = (excludePatp) => {
+  return Object.entries(
+    Object.values(get(state))
+      .filter(
+        (k) =>
+          k?.keyObj?.ship !== excludePatp &&
+          k?.keyObj?.struc === 'collection' &&
+          k?.keyObj?.time !== 'global' &&
+          k?.keyObj?.time !== 'index'
+      )
+      .reduce((a, b) => {
+        b?.bespoke?.['key-list']
+          .filter((k) => k?.struc !== 'collection')
+          .forEach((k) => {
+            if (!a[keyStrFromObj(k)]) return (a[keyStrFromObj(k)] = 1);
+            a[keyStrFromObj(k)]++;
+          });
+        return a;
+      }, {})
+  ).sort((a, b) => b[1] - a[1]);
+};
+
 // export const getProfile = (ship) => {
 //   return get(state).profiles?.[ship];
 // };


### PR DESCRIPTION
Looks through all the collections we have in state and counts the instances of items appearing in each collection. Thus it will potentially change as we subscribe to more people.

Perhaps counterintuitively, it won't count the instances of people "recommending" items into the feed... but this can probably be solved easily if we want to.

<img width="1582" alt="image" src="https://github.com/worpet-bildet/portal/assets/2966123/21a9fad8-4400-4409-be76-eb788aaabb19">
