### PR TITLE
more from ~ship recommendations

### DIFF
--- a/ui/src/components/ItemDetail.svelte
+++ b/ui/src/components/ItemDetail.svelte
@@ -89,7 +89,7 @@
       <div class="gap-4">
         <!-- TODO: get any links in here to print nicely -->
         {#if description}<div>{description}</div>{/if}
-        {#if type === 'collection' || type === 'app'}<a
+        {#if type === 'collection' || type === 'app' || type === 'group'}<a
             use:link
             class="text-sm hover:text-grey hover:duration-500"
             href={`/${patp}`}

--- a/ui/src/pages/App.svelte
+++ b/ui/src/pages/App.svelte
@@ -8,6 +8,7 @@
     keyStrFromObj,
     getReviews,
     getReviewsByTo,
+    getMoreFromThisShip,
   } from '@root/state';
   import { getMeta, fromUrbitTime } from '@root/util';
   import {
@@ -15,6 +16,7 @@
     RecommendModal,
     FeedPost,
     FeedPostForm,
+    ItemVerticalListPreview,
   } from '@components';
   import {
     RightSidebar,
@@ -140,9 +142,11 @@
     isReviewedByMe = reviews.find((r) => r.ship === me);
   };
 
+  let sortedRecommendations = [];
   state.subscribe((s) => {
     if (!s.isLoaded) return;
     loadApp(s);
+    sortedRecommendations = getMoreFromThisShip(ship).slice(0, 4);
   });
 
   const uninstall = () => {
@@ -371,6 +375,14 @@
           >
         {/if}
       </SidebarGroup>
+      {#if sortedRecommendations.length > 0}
+        <SidebarGroup>
+          <div class="text-lg mx-1">More from {ship}</div>
+          {#each sortedRecommendations as [recommendation, count]}
+            <ItemVerticalListPreview key={keyStrToObj(recommendation)} small />
+          {/each}
+        </SidebarGroup>
+      {/if}
     </RightSidebar>
   </div>
   <RecommendModal bind:open={recommendModalOpen} key={keyStrToObj(itemKey)} />

--- a/ui/src/pages/Collection/Collection.svelte
+++ b/ui/src/pages/Collection/Collection.svelte
@@ -1,7 +1,7 @@
 <script>
   import { push, pop } from 'svelte-spa-router';
   import { me } from '@root/api';
-  import { state, getItem, getCollectionItems, getCurator } from '@root/state';
+  import { state, getItem, getCollectionItems, getCurator, keyStrToObj, getMoreFromThisShip } from '@root/state';
   import { getMeta } from '@root/util';
   import {
     ItemDetail,
@@ -24,10 +24,12 @@
 
   let collection, items, recommendModalOpen;
 
+  let sortedRecommendations = [];
   state.subscribe(() => {
     collection = getItem(collectionKey);
     if (!collection) return;
     items = getCollectionItems(collection.keyStr);
+    sortedRecommendations = getMoreFromThisShip(ship).slice(0, 4);
   });
 </script>
 
@@ -63,6 +65,14 @@
           >
         {/if}
       </SidebarGroup>
+      {#if sortedRecommendations.length > 0}
+        <SidebarGroup>
+          <div class="text-lg mx-1">More from {ship}</div>
+          {#each sortedRecommendations as [recommendation, count]}
+            <ItemVerticalListPreview key={keyStrToObj(recommendation)} small />
+          {/each}
+        </SidebarGroup>
+      {/if}
     </RightSidebar>
   </div>
   <RecommendModal bind:open={recommendModalOpen} key={collection.keyObj} />

--- a/ui/src/pages/Curator/Curator.svelte
+++ b/ui/src/pages/Curator/Curator.svelte
@@ -6,6 +6,8 @@
     getCuratorFeed,
     refreshPals,
     getCuratorFeaturedCollection,
+    keyStrToObj,
+    getMoreFromThisShip,
   } from '@root/state';
   import { subscribeToCurator, addPal, removePal, me } from '@root/api';
   import { getMeta } from '@root/util';
@@ -49,9 +51,11 @@
     loadCurator();
   }
 
+  let sortedRecommendations = [];
   state.subscribe((s) => {
     if (!s) return;
     loadCurator();
+    sortedRecommendations = getMoreFromThisShip(patp).slice(0, 4);
   });
 
   const togglePal = () => {
@@ -128,7 +132,7 @@
       {#if curator?.bespoke?.groups?.length > 0}
         <SidebarGroup>
           <div class="grid gap-y-4">
-            <div>{patp} recommends</div>
+            <div class="text-lg mx-1">{patp} recommends</div>
             {#each curator.bespoke.groups as key}
               <ItemVerticalListPreview
                 small
@@ -141,6 +145,14 @@
               />
             {/each}
           </div>
+        </SidebarGroup>
+      {/if}
+      {#if sortedRecommendations.length > 0}
+        <SidebarGroup>
+          <div class="text-lg mx-1">More from {patp}</div>
+          {#each sortedRecommendations as [recommendation, count]}
+            <ItemVerticalListPreview key={keyStrToObj(recommendation)} small />
+          {/each}
         </SidebarGroup>
       {/if}
     </RightSidebar>

--- a/ui/src/pages/Group.svelte
+++ b/ui/src/pages/Group.svelte
@@ -5,10 +5,11 @@
     getJoinedGroupDetails,
     refreshGroups,
     keyStrToObj,
+    getMoreFromThisShip,
   } from '@root/state';
   import { joinGroup, leaveGroup, subscribeToItem } from '@root/api';
   import { getMeta } from '@root/util';
-  import { ItemDetail, RecommendModal } from '@components';
+  import { ItemDetail, RecommendModal, ItemVerticalListPreview } from '@components';
   import {
     ChatIcon,
     DiaryIcon,
@@ -41,9 +42,11 @@
   }
 
   let group, joinedDetails;
+  let sortedRecommendations = [];
   state.subscribe((s) => {
     if (!s.isLoaded) return;
     loadGroup();
+    sortedRecommendations = getMoreFromThisShip(host).slice(0, 4);
   });
 
   const join = () => joinGroup(groupKey).then(refreshGroups);
@@ -59,7 +62,7 @@
 {#if group}
   {@const { cover, image, description, title } = getMeta(group)}
   <div class="grid grid-cols-12 gap-x-8 mb-4">
-    <ItemDetail {cover} avatar={image} {title} {description} type="group">
+    <ItemDetail {cover} avatar={image} {title} {description} patp={host} type="group">
       <div class="col-span-12 md:col-span-9 bg-panels p-6 rounded-lg">
         {#if !joinedDetails}
           <div>Join the group to see more information</div>
@@ -141,6 +144,14 @@
           on:click={() => (recommendModalOpen = true)}>Recommend</IconButton
         >
       </SidebarGroup>
+      {#if sortedRecommendations.length > 0}
+        <SidebarGroup>
+          <div class="text-lg mx-1">More from {host}</div>
+          {#each sortedRecommendations as [recommendation, count]}
+            <ItemVerticalListPreview key={keyStrToObj(recommendation)} small />
+          {/each}
+        </SidebarGroup>
+      {/if}
     </RightSidebar>
     <!-- <div class="hidden lg:flex lg:col-span-3 flex-col gap-8">
       {#if curator && curator.groups && curator.groups.length > 0}

--- a/ui/src/state.js
+++ b/ui/src/state.js
@@ -203,6 +203,27 @@ export const getCollectedItemLeaderboard = (excludePatp) => {
   ).sort((a, b) => b[1] - a[1]);
 };
 
+export const getMoreFromThisShip = (patp) => {
+  return Object.entries(
+    Object.values(get(state))
+      .filter(
+        (k) =>
+          k?.keyObj?.struc === 'collection' &&
+          k?.keyObj?.time !== 'global' &&
+          k?.keyObj?.time !== 'index'
+      )
+      .reduce((a, b) => {
+        b?.bespoke?.['key-list']
+          .filter((k) => k?.struc !== 'collection' && k?.ship === patp)
+          .forEach((k) => {
+            if (!a[keyStrFromObj(k)]) return (a[keyStrFromObj(k)] = 1);
+            a[keyStrFromObj(k)]++;
+          });
+        return a;
+      }, {})
+  ).sort((a, b) => b[1] - a[1]);
+};
+
 // export const getProfile = (ship) => {
 //   return get(state).profiles?.[ship];
 // };


### PR DESCRIPTION
this makes it a bit easier to navigate around and find new items

it's still not THAT useful because it only surfaces items you've already happened upon - a true central index is still needed to help esp first-time urbiters with discovery

TODO:
- doesnt work on groups pages on first load, but does work after refresh
- unable to test collections pages